### PR TITLE
feat: Add Devin CLI completions to Zsh configuration

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -163,3 +163,8 @@ gdiff-staged() {
     ':(exclude)pnpm-lock.yaml' \
     ':(exclude)composer.lock' | xclip -selection clipboard
 }
+
+# Add devin completions
+if command -v devin &> /dev/null; then
+  eval "$(devin completions)"
+fi


### PR DESCRIPTION
### Summary
This PR enhances the developer experience by adding intelligent command-line auto-completion support for the `devin` tool in the Zsh shell. When developers type `devin` commands, they will now receive helpful suggestions and completions, making the tool easier and faster to use.

### Technical Changes
*   **Modified Component:** Updated the `~/.zshrc` configuration file to include Devin CLI completions
*   **Logic Addition:** Added conditional logic that automatically sources Devin's completion script when the `devin` command is available in the system PATH
*   **Implementation Details:**
    *   Uses `command -v devin` to check for Devin's presence before attempting to load completions
    *   Executes `$(devin completions)` to generate and source the completion definitions
    *   The conditional check prevents errors if Devin is not installed on the system
*   **File Format:** Added proper newline at end of file to maintain POSIX compliance

### Commit Messages Reference
*   `feat: add devin completions support - Integrate command-line completions for the devin tool. The completions are automatically sourced if the devin command is available in the system PATH.`